### PR TITLE
fixed panic in estimateBias when there is a hit at first iteration

### DIFF
--- a/auxillary.go
+++ b/auxillary.go
@@ -62,7 +62,12 @@ func estimateBias(E float64, p uint8) float64 {
 
 	biasVector := biasData[p-4]
 
-	for i, v := range estimateVector[1:] {
+	if estimateVector[0] == E {
+		return biasVector[0]
+	}
+
+	for i := 1; i < len(estimateVector); i++ {
+		v := estimateVector[i]
 		if v == E {
 			return biasVector[i]
 		}

--- a/auxillary_test.go
+++ b/auxillary_test.go
@@ -80,3 +80,12 @@ func TestEstimateBias(t *testing.T) {
 		t.Fatalf("Incorrect bias estimate.  Calculated %f, should be closer to %f", bias, actualBias)
 	}
 }
+
+func TestEstimateBias2(t *testing.T) {
+	bias := estimateBias(11822.412839663843, 14)
+	actualBias := 11811.188669
+
+	if math.Abs(bias/actualBias-1) > 0.01 {
+		t.Fatalf("Incorrect bias estimate.  Calculated %f, should be closer to %f", bias, actualBias)
+	}
+}


### PR DESCRIPTION
Hi, we had an issue in our application, when E converges to  estimateVector at first iteration, so  it panics at estimateVector[i-1:i+1] when i is 0. I added TestEstimateBias2 with parameters we have in our case. It looks valid to skip iteration 0 and start from 1 in this function. Please, take a look. 