### PR TITLE
using math/bits instead of custom bit operations

### DIFF
--- a/auxillary.go
+++ b/auxillary.go
@@ -2,6 +2,7 @@ package gohll
 
 import (
 	"math"
+	"math/bits"
 )
 
 // encodeHash takes in a 64bit hash and the set precision and outputs a 32bit
@@ -11,7 +12,7 @@ func encodeHash(x uint64, p uint8) uint32 {
 		var result uint32
 		result = uint32((x >> 32) &^ 0x7f)
 		w := sliceUint64(x, 63-p, 0) << p
-		result |= (uint32(leadingBitUint64(w)) << 1)
+		result |= (uint32(bits.LeadingZeros64(w)) << 1)
 		result |= 1
 		return result
 	}
@@ -26,7 +27,7 @@ func decodeHash(x uint32, p uint8) (uint32, uint8) {
 	if x&0x1 == 1 {
 		r = uint8(sliceUint32(x, 6, 1))
 	} else {
-		r = leadingBitUint32(sliceUint32(x, 31-p, 1) << (1 + p))
+		r = uint8(bits.LeadingZeros32(sliceUint32(x, 31-p, 1) << (1 + p)))
 	}
 	return getIndex(x, p), r + 1
 

--- a/auxillary_test.go
+++ b/auxillary_test.go
@@ -2,6 +2,7 @@ package gohll
 
 import (
 	"math"
+	"math/bits"
 	"math/rand"
 	"testing"
 
@@ -62,7 +63,7 @@ func TestEncodeDecode3(t *testing.T) {
 
 		index := sliceUint64(hash, 63, 64-p)
 		w := sliceUint64(hash, 63-p, 0) << p
-		rho := leadingBitUint64(w) + 1
+		rho := bits.LeadingZeros64(w) + 1
 
 		e := encodeHash(hash, p)
 		edIndex, edRho := decodeHash(e, p)

--- a/bitoperations.go
+++ b/bitoperations.go
@@ -37,38 +37,3 @@ func sliceUint64(N uint64, start, stop uint8) uint64 {
 	}
 	return r
 }
-
-// LeadingBitUint32 returns what index has the first non-zero bit with the
-// leading bit being indexed at 0 and the last bit indexed at 32
-//
-// LeadingBitUint32(0xffffffff) = 0
-// LeadingBitUint32(0x0fffffff) = 3
-// LeadingBitUint32(0x00ffffff) = 7
-// LeadingBitUint32(0x00000000) = 32
-func leadingBitUint32(N uint32) uint8 {
-	if N == 0 {
-		return 32
-	}
-	t := uint32(1 << 31)
-	r := uint8(0)
-	for (N & t) == 0 {
-		t >>= 1
-		r++
-	}
-	return r
-}
-
-// LeadingBitUint64 returns what index has the first non-zero bit with the
-// leading bit being indexed at 0 and the last bit indexed at 64
-func leadingBitUint64(N uint64) uint8 {
-	if N == 0 {
-		return 64
-	}
-	t := uint64(1 << 63)
-	r := uint8(0)
-	for (N & t) == 0 {
-		t >>= 1
-		r++
-	}
-	return r
-}

--- a/bitoperations_test.go
+++ b/bitoperations_test.go
@@ -37,37 +37,3 @@ func TestSliceUint64(t *testing.T) {
 	result = sliceUint64(N, start, stop)
 	assert.Equal(t, result, ideal, "Incorrect uint64 slice")
 }
-
-func TestLeadingBitUint32(t *testing.T) {
-	N := uint32(0xffffffff)
-	ideal := uint8(0)
-	result := leadingBitUint32(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-
-	N = uint32(0x00000000)
-	ideal = uint8(32)
-	result = leadingBitUint32(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-
-	N = uint32(0x00f00000)
-	ideal = uint8(2 * 4)
-	result = leadingBitUint32(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-}
-
-func TestLeadingBitUint64(t *testing.T) {
-	N := uint64(0xffffffffffffffff)
-	ideal := uint8(0)
-	result := leadingBitUint64(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-
-	N = uint64(0x0000000000000000)
-	ideal = uint8(64)
-	result = leadingBitUint64(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-
-	N = uint64(0x0000f00000000000)
-	ideal = uint8(4 * 4)
-	result = leadingBitUint64(N)
-	assert.Equal(t, result, ideal, "Incorrect Leading Bit")
-}

--- a/gohll.go
+++ b/gohll.go
@@ -8,6 +8,7 @@ package gohll
 import (
 	"errors"
 	"math"
+	"math/bits"
 
 	"github.com/mynameisfiber/gohll/mmh3"
 )
@@ -140,7 +141,7 @@ func (h *HLL) AddHash(hash uint64) {
 func (h *HLL) addNormal(hash uint64) {
 	index := sliceUint64(hash, 63, 64-h.P)
 	w := sliceUint64(hash, 63-h.P, 0) << h.P
-	rho := leadingBitUint64(w) + 1
+	rho := uint8(bits.LeadingZeros64(w) + 1)
 	if h.registers[index] < rho {
 		h.registers[index] = rho
 	}

--- a/sparselist.go
+++ b/sparselist.go
@@ -67,7 +67,7 @@ func (sl *sparseList) Clear() {
 // Merge will merge this sparse list with another mergable list.  This is done
 // by having the 32bit integers within the list sorted by it's encoded index
 // and, if another item with the same index exists, only keeping the one with
-// the largest number of leading zero bits (as given by leadingBitUint32).
+// the largest number of leading zero bits.
 //
 // NOTE: This function assumes that this list is already sorted with the given
 // Less() function


### PR DESCRIPTION
As discussed in https://github.com/mynameisfiber/gohll/issues/12, this patch removes functions that operate on bits and replaces it with stl's math/bits.